### PR TITLE
feat: add opentelemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-deps/
-.eunit/
-*.beam
-*.app
-*.plt
+_build

--- a/rebar.config
+++ b/rebar.config
@@ -9,6 +9,7 @@
 {cover_print_enabled, true}.
 {deps,
  [ {stdlib2, ".*", {git, "https://github.com/kivra/stdlib2", {branch, "master"}}}
+ , {opentelemetry_api,  "~> 1.0"}
  , {eon,     ".*", {git, "https://github.com/kivra/eon",     {branch, "master"}}}
  ]}.
 

--- a/src/greph.app.src
+++ b/src/greph.app.src
@@ -1,6 +1,6 @@
 {application, greph, [ {description,  "greph"}
                      , {vsn,          git}
-                     , {applications, [kernel, stdlib]}
+                     , {applications, [kernel, stdlib, eon, stdlib2, opentelemetry_api]}
                      , {env,          []}
                      , {registered,   []}
                      ]}.


### PR DESCRIPTION
In kivra core we use the `pre_fun` and `post_fun` callbacks to wrap an open-telemetry span around each stage.

the problem with that is that values needed for this stage will evaluate inside this, and that will be surrounded with its pair of pre/post funs

the resulting opentelemetry trace will then be nested instead of being siblings.

so if greph itself surrounds the eval with a span, they will end up being sibling traces.

to use this one should stop using `pre_fun` and `post_fun` in kivra core or wherever your rest_prelude is using this.